### PR TITLE
Parts Names have Wrong Case

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ReactorPack/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ReactorPack/CTT.cfg
@@ -1,19 +1,19 @@
-@PART[USI_NUKE_625]:NEEDS[CommunityTechTree]
+@PART[USI_Nuke_625]:NEEDS[CommunityTechTree]
 {
     @TechRequired = nuclearPower
 }
 
-@PART[USI_NUKE_125]:NEEDS[CommunityTechTree]
+@PART[USI_Nuke_125]:NEEDS[CommunityTechTree]
 {
     @TechRequired = nuclearPower
 }
 
-@PART[USI_NUKE_250]:NEEDS[CommunityTechTree]
+@PART[USI_Nuke_250]:NEEDS[CommunityTechTree]
 {
     @TechRequired = largeNuclearPower
 }
 
-@PART[USI_NUKE_375]:NEEDS[CommunityTechTree]
+@PART[USI_Nuke_375]:NEEDS[CommunityTechTree]
 {
     @TechRequired = largeNuclearPower
 }


### PR DESCRIPTION
Reactors parts names have wrong case in CTT patch