### PR TITLE
Hide KIS Kontainers if KIS isn't installed

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_01.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KIS]
 {
 // --- general parameters ---
 name = C3_Kontainer_KIS_01

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_02.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KIS]
 { 
 // --- general parameters ---
 name = C3_Kontainer_KIS_02

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_03.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KIS]
 {
 // --- general parameters ---
 name = C3_Kontainer_KIS_03

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_04.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_04.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KIS]
 {
 // --- general parameters ---
 name = C3_Kontainer_KIS_04

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_M.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_KIS_M.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KIS]
 {
 // --- general parameters ---
 name = C3_Kontainer_KIS_M


### PR DESCRIPTION
The KIS Kontainers are useless without KIS installed, so they shouldn't appear in the parts list in that case.