### PR TITLE
Clean develop

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_CLS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_CLS.cfg
@@ -1,0 +1,13 @@
+//
+//  All the *solids* and KIS Kontainers are passable - the *fluids/liquids* are not.
+//  (You have to enter to get the stacks/boxes of materials out of the solids - but the fluids are pumped out.)
+//
+
+@PART[C3_FlatTank_*,C3_Kontainer_*]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_CLS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_CLS.cfg
@@ -3,11 +3,25 @@
 //  (You have to enter to get the stacks/boxes of materials out of the solids - but the fluids are pumped out.)
 //
 
-@PART[C3_FlatTank_*,C3_Kontainer_*]
+@PART[C3_FlatTank_*,C3_Kontainer_*]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
+	}
+}
+
+//
+// Some of the fluids Kontainers are *optionally* passable - Their design allows it, but it's not
+// the default.
+//
+
+@PART[C3_RTank_01,C3_RTank_02,C3_RTank_03,C3_RTank_04,C3_RTank_06,C3_RTank_08]:NEEDS[ConnectedLivingSpace]
+{
+        MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false
 	}
 }


### PR DESCRIPTION
Added CLS support to the Kontainers:

 - Solids/KIS Kontainers get passability
 - Fluids Kontainers to not get passability

The theory is that you have to enter/exit to pull whatever is in the Kontainer out.  As it’s just a box, there’s no restrictions on where the doors are placed.  Fluids are tanks, and have to be pumped out - no built-in passability.  (Though some can be retrofitted in the VAB.)

This allows Kontainers to be used inline in base construction.