### PR TITLE
Positioning fix for mountable kontainers

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
@@ -7,19 +7,19 @@ PART:NEEDS[KIS]
 	MODEL
 	{
 		model = UmbraSpaceIndustries/Kontainers/Assets/MountableBase
-		position = 0.0, -0.34, 0.0
+		position = 0.0, -0.247985, 0.0  // Match KIS_Container1's origin
 		texture = KIS_containerS_cs, KIS/Parts/container1/KIS_containerS_cs
 		texture = KIS_containerS_n, KIS/Parts/container1/KIS_containerS_n
 	}
 	MODEL
 	{
 		model = UmbraSpaceIndustries/Kontainers/Assets/MountableLqdTank
-		position = 0.0, -0.34, 0.0
+		position = 0.0, -0.247985, 0.0  // Match KIS_Container1's origin
 	}
 
 	scale = 1
 
-	node_stack_bottom = 0.0, -0.34, 0.0, 0.0, -1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.2477, 0.0, 0.0, -1.0, 0.0, 0
 
 	TechRequired = advConstruction
 	entryCost = 4160

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
@@ -7,19 +7,19 @@ PART:NEEDS[KIS]
 	MODEL
 	{
 		model = UmbraSpaceIndustries/Kontainers/Assets/MountableBase
-		position = 0.0, -0.34, 0.0
+		position = 0.0, -0.247985, 0.0  // Match KIS_Container1's origin
 		texture = KIS_containerS_cs, KIS/Parts/container1/KIS_containerS_cs
 		texture = KIS_containerS_n, KIS/Parts/container1/KIS_containerS_n
 	}
 	MODEL
 	{
 		model = UmbraSpaceIndustries/Kontainers/Assets/MountableSupPack
-		position = 0.0, -0.34, 0.0
+		position = 0.0, -0.247985, 0.0  // Match KIS_Container1's origin
 	}
 
 	scale = 1
 
-	node_stack_bottom = 0.0, -0.34, 0.0, 0.0, -1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.2477, 0.0, 0.0, -1.0, 0.0, 0
 
 	TechRequired = advConstruction
 	entryCost = 4160


### PR DESCRIPTION
The `.cfg` file for the KIS-mountable kontainers (#60) has a problem with the location of the model's origin and attachment node.  I was planning to check in the fix along with the new models, but since the version with the bug has already been merged, I'd like to make this fix right away, before they're released.  It makes the parts appear in the correct position on a kerbal's back when carried in the kerbal's inventory.

Please merge this before releasing any USI updates that include the mountable kontainer parts.  If people build ships using the original version of the config and then the fix gets released later, the parts will change position and appear to float in space above whatever they're attached to.  (Not a huge problem, but something I'd like to avoid.)